### PR TITLE
Check both legacy SNI port and current SNI port for the websocket

### DIFF
--- a/packages/tracker-core/SnesSession.ts
+++ b/packages/tracker-core/SnesSession.ts
@@ -21,7 +21,8 @@ type WsConnection = ws.connection;
 
 const queue = new Queue(1);
 
-const wsServer = "ws://localhost:8080";
+const wsServer1 = "ws://localhost:23074";
+const wsServer2 = "ws://localhost:8080";
 
 export class SnesSession {
   public info: SnesInfo | null;
@@ -51,7 +52,7 @@ export class SnesSession {
     this._devicePromise = null;
     this._deviceInfoPromise = null;
     this._attachPromise = null;
-    this._externalLogger = () => {};
+    this._externalLogger = () => { };
     this.error = null;
   }
 
@@ -92,7 +93,11 @@ export class SnesSession {
     this.resetState();
 
     if (!this._client) {
-      this._client = new ws.w3cwebsocket(wsServer);
+      this._client = new ws.w3cwebsocket(wsServer1);
+    }
+
+    if (!this._client) {
+      this._client = new ws.w3cwebsocket(wsServer2);
     }
 
     this._isConnected = false;

--- a/packages/tracker-core/SnesSession.ts
+++ b/packages/tracker-core/SnesSession.ts
@@ -21,8 +21,8 @@ type WsConnection = ws.connection;
 
 const queue = new Queue(1);
 
-const wsServer1 = "ws://localhost:23074";
-const wsServer2 = "ws://localhost:8080";
+const wsServer = "ws://localhost:23074";
+const wsServerLegacyPort = "ws://localhost:8080";
 
 export class SnesSession {
   public info: SnesInfo | null;
@@ -92,12 +92,13 @@ export class SnesSession {
   public async connect() {
     this.resetState();
 
+    // SNI changed the port it listens on. Check current and legacy ports
     if (!this._client) {
-      this._client = new ws.w3cwebsocket(wsServer1);
+      this._client = new ws.w3cwebsocket(wsServer);
     }
 
     if (!this._client) {
-      this._client = new ws.w3cwebsocket(wsServer2);
+      this._client = new ws.w3cwebsocket(wsServerLegacyPort);
     }
 
     this._isConnected = false;


### PR DESCRIPTION
SNI depreacted using the 8080 port and switched to using 23074. This change makes the tracker try to connect on the newer port first and if it fails it tries the legacy port.